### PR TITLE
Using MaskedArray instead of NaNs

### DIFF
--- a/iris/raw.py
+++ b/iris/raw.py
@@ -280,8 +280,7 @@ class RawDataset(object):
             
             # truncate the sides of 'cube' along axes (0, 1) due to the
             # window size of the center finder. Since the center can move by
-            # as much as 'window_size' pixels in both all directions, we can
-            # save space and avoid a lot of NaNs.
+            # as much as 'window_size' pixels in both all directions
             image = n.empty(shape = self.resolution, dtype = n.uint16)
             cube = n.ma.empty(shape = self.resolution + (len(self.nscans),), dtype = n.float, fill_value = 0.0)
             deviation = n.ma.empty_like(cube, dtype = n.float)
@@ -295,7 +294,6 @@ class RawDataset(object):
                 # Concatenate time-delay in data cube
                 # Last axis is the scan number
                 # Before concatenation, shift around for center
-                # Invalid pixels (such as border pixels, and beamblock pixels) are NaN
                 missing_pictures = 0
                 slice_index = 0
                 for scan in self.nscans:
@@ -308,7 +306,7 @@ class RawDataset(object):
                     
                     corr_i, corr_j = n.array(center) - find_center(image, guess_center = center, radius = radius, 
                                                                           window_size = window_size, ring_width = 5)
-                    cube[:,:,slice_index] = shift(image, int(round(corr_i)), int(round(corr_j)), fill = n.nan)
+                    cube[:,:,slice_index] = shift(image, int(round(corr_i)), int(round(corr_j)))
                     slice_index += 1
                 
                 # cube possibly has some empty slices due to missing pictures

--- a/iris/tests/test_utils.py
+++ b/iris/tests/test_utils.py
@@ -23,15 +23,11 @@ class TestShift(unittest.TestCase):
     
     def test_shift_out_of_bounds(self):
         array = n.ones(shape = (256, 256), dtype = n.float)
-        shifted_x = shift(array, 300, 0, fill = n.nan)
-        self.assertTrue(n.isnan(shifted_x).sum() == array.size)  # Sum of number of NaNs is same as number of elements
+        shifted_x = shift(array, 300, 0)
+        self.assertTrue(shifted_x.mask.sum() == array.size)  # Sum of number of NaNs is same as number of elements
 
-        shifted_y = shift(array, 0, -451, fill = n.nan)
-        self.assertTrue(n.isnan(shifted_y).sum() == array.size)  # Sum of number of NaNs is same as number of elements
-    
-    def test_shift_non_int(self):
-        array = n.ones(shape = (256, 256), dtype = n.float)
-        shifted_x = shift(array, 34.5, -0.1, fill = n.nan)
+        shifted_y = shift(array, 0, -451)
+        self.assertTrue(shifted_y.mask.sum() == array.size)  # Sum of number of NaNs is same as number of elements
 
 class TestAngularAverage(unittest.TestCase):
 

--- a/iris/utils.py
+++ b/iris/utils.py
@@ -55,17 +55,23 @@ def scattering_length(radius, energy, pixel_width = 14e-6, camera_distance = 0.2
     diffraction_half_angle = n.arctan(radius/camera_distance)/2
     return n.sin(diffraction_half_angle)/electron_wavelength(energy, units = 'angstroms')
 
-def shift(arr, x, y, fill = n.nan):
+def shift(arr, x, y):
     """
     Shift an array to center.
 
     Parameters
     ----------
+    arr : ndarray
     x : int
     y : int
-    fill : numeric
+
+    Returns
+    -------
+    out : MaskedArray
     """
-    shifted = fill * n.ones_like(arr)
+    shifted = n.empty_like(arr)
+    shifted.fill(n.nan)
+
     if x > 0:
         x_source = slice(0, -x)
         x_cast = slice(x, None)
@@ -87,7 +93,7 @@ def shift(arr, x, y, fill = n.nan):
         y_cast = slice(0, None)
     
     shifted[x_cast, y_cast] = arr[x_source, y_source]
-    return shifted
+    return n.ma.masked_where(n.isnan(shifted), shifted)
 
 def average_tiff(directory, wildcard, background = None):
     """


### PR DESCRIPTION
In order to simplify the processing code, the use of NaNs to represent
invalid data was changed to numpy.ma.MaskedArray.