### PR TITLE
Added Bragg peak functionality

### DIFF
--- a/iris/gui/bragg_peak_dialog.py
+++ b/iris/gui/bragg_peak_dialog.py
@@ -1,0 +1,259 @@
+# -*- coding: utf-8 -*-
+"""
+Dialog for processing between AbstractRawDataset and DiffractionDataset
+"""
+
+import numpy as np
+import pyqtgraph as pg
+from PyQt5 import QtCore, QtGui, QtWidgets
+import numpy as np
+import pyqtgraph as pg
+from PyQt5 import QtCore, QtWidgets
+from skued import bragg_peaks, autocenter
+from .controller import WorkThread
+from .qbusyindicator import QBusyIndicator
+from .processing_dialog import MaskCreator
+
+class RectROIWithCenter(pg.RectROI):
+
+    # Calculating the center position assumes that PyQtGraph is configured
+    # such that imageAxisOrder == 'row-major'
+    def center(self):
+        corner_x, corner_y = self.pos().x(), self.pos().y()
+        return (round(corner_x + self.size().x() / 2), round(corner_y + self.size().y() / 2))
+
+    def set_center(self, x, y):
+        left = x - self.size().x() / 2
+        bottom = y - self.size().y() / 2
+        self.setPos(left, bottom)
+# -*- coding: utf-8 -*-
+
+description = (
+    """Auto-determine the Bragg peak positions and add manually those not found. Subsequent calculation will optimize and realign the Bragg peaks to local maxima. """
+)
+
+class BraggPeakDialog(QtWidgets.QDialog):
+    """
+    Modal dialog to determine Bragg peak locations and corresponding
+    2D projections of Brilluoin zones
+    """
+
+    bragg_peak_signal = QtCore.pyqtSignal(dict)
+
+    def __init__(self, image, mask, center=None, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        image : ndarray
+            Diffraction pattern to be displayed.
+        """
+        super().__init__(*args, **kwargs)
+        self.setModal(True)
+        self.setWindowTitle("Calculate Bragg peaks")
+        self.__bragg_peak_items = list()
+        self.__bragg_peaks = list()
+        # For use with autopeak
+        self._image = image
+        self._mask = mask
+        self._resolution = np.array(self._image.shape)
+        title = QtWidgets.QLabel("<h2>Bragg peak options<\\h2>")
+        title.setTextFormat(QtCore.Qt.RichText)
+        title.setAlignment(QtCore.Qt.AlignCenter)
+
+        description_label = QtWidgets.QLabel(description, parent=self)
+        description_label.setWordWrap(True)
+        description_label.setAlignment(QtCore.Qt.AlignCenter)
+
+        self.viewer = pg.ImageView(parent=self)
+        self.viewer.setSizePolicy(
+            QtWidgets.QSizePolicy.MinimumExpanding,
+            QtWidgets.QSizePolicy.MinimumExpanding,
+        )
+        self.viewer.setImage(image)
+    
+        self.center_finder = RectROIWithCenter(
+            pos=np.array(image.shape) / 2 - 100, size=[50, 50]#, pen=pg.mkPen("r")
+        )
+        # self.autocenter = autocenter(self._image, self._mask)
+        # self.center_finder.set_center(self.autocenter[1], self.autocenter[0])
+        if center is not None and center != (0, 0):
+            self.center_finder.set_center(*center)
+
+        self.viewer.getView().addItem(self.center_finder)
+
+
+        self.accept_btn = QtWidgets.QPushButton("Calculate", self)
+        self.accept_btn.clicked.connect(self.accept)
+
+        self.cancel_btn = QtWidgets.QPushButton("Cancel", self)
+        self.cancel_btn.clicked.connect(self.reject)
+        self.cancel_btn.setDefault(True)
+
+        self.autopeak_btn = QtWidgets.QPushButton("Auto-detection", self)
+        self.autopeak_btn.clicked.connect(self.initiate_autopeaks)
+        self.autopeak_btn.setSizePolicy(
+            QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum
+        )
+        self.busy_indicator = QBusyIndicator(parent=self)
+        autopeak_layout = QtWidgets.QHBoxLayout()
+        autopeak_layout.addWidget(self.autopeak_btn)
+        autopeak_layout.addWidget(self.busy_indicator)
+
+        self.add_circ_mask_btn = QtWidgets.QPushButton("Add new peak", self)
+        self.add_circ_mask_btn.setSizePolicy(
+            QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum
+        )
+        self.add_circ_mask_btn.clicked.connect(self.add_bragg_peak)
+        self.add_circ_mask_btn.setEnabled(False)
+
+        self.vertices_widget = QtWidgets.QSpinBox(parent=self)
+        self.vertices_widget.setRange(1, 12)
+        self.vertices_widget.setValue(6)
+    
+        self.vertices_layout = QtWidgets.QFormLayout()
+        self.vertices_layout.addRow("Number of vertices:", self.vertices_widget)
+
+        btns = QtWidgets.QHBoxLayout()
+        btns.addWidget(self.accept_btn)
+        btns.addWidget(self.cancel_btn)
+
+        params_layout = QtWidgets.QVBoxLayout()
+        params_layout.addWidget(title)
+        params_layout.addWidget(description_label)
+        params_layout.addLayout(autopeak_layout)
+        params_layout.addWidget(self.add_circ_mask_btn)
+        params_layout.addLayout(self.vertices_layout)
+        params_layout.addLayout(btns)
+
+        params_widget = QtWidgets.QFrame(parent=self)
+        params_widget.setLayout(params_layout)
+        params_widget.setFrameShadow(QtWidgets.QFrame.Sunken)
+        params_widget.setFrameShape(QtWidgets.QFrame.Panel)
+        params_widget.setSizePolicy(
+            QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum
+        )
+
+        right_layout = QtWidgets.QVBoxLayout()
+        right_layout.addWidget(params_widget)
+        right_layout.addStretch()
+
+        self.layout = QtWidgets.QHBoxLayout()
+        self.layout.addWidget(self.viewer)
+        self.layout.addLayout(right_layout)
+        self.setLayout(self.layout)
+
+        self.initiate_autopeaks()
+
+    @QtCore.pyqtSlot()
+    def add_bragg_peak(self):
+        new_roi = pg.RectROI(
+            pos=self._resolution/2,
+            size=(50,50),
+            resizable=False
+        )
+        self.viewer.addItem(new_roi)
+        self.__bragg_peak_items.append(new_roi)
+
+
+    @QtCore.pyqtSlot()
+    def accept(self):
+        # Calculating the center position assumes that PyQtGraph is configured
+        # such that imageAxisOrder == 'row-major'
+        
+        for item in self.__bragg_peak_items:
+            self.__bragg_peaks.append([item.pos().x(), item.pos().y()])
+        params = {
+            "peaks" : self.__bragg_peaks,
+            "sym" : int(self.vertices_widget.value())
+        }
+        self.bragg_peak_signal.emit(params)
+        super().accept()
+
+    @QtCore.pyqtSlot()
+    def initiate_autopeaks(self):
+        """Automatically determine the bragg peaks
+        and move the center-finder accordingly"""
+        self._worker = AutobraggpeakThread(
+            function=bragg_peaks, kwargs=dict(im=self._image, mask=self._mask, min_dist=50)
+        )
+
+        self._worker.results_signal.connect(self.set_peaks)
+        self._worker.in_progress_signal.connect(self.busy_indicator.toggle_animation)
+        self._worker.in_progress_signal.connect(self.autopeak_btn.setDisabled)
+        self._worker.start()
+
+    @QtCore.pyqtSlot(object)
+    def set_peaks(self, rc):
+        for item in self.__bragg_peak_items:
+            self.image_viewer.removeItem(item)
+        self.__bragg_peak_items.clear()
+
+        # self.__bragg_peak_items.append(self.center_finder)
+        for idx, peak in enumerate(rc):
+            r, c = peak
+            self.__bragg_peak_items.append(
+                pg.RectROI(
+                    pos=(c-25, r-25), size=(50,50), movable=True, resizable=False, removable=True
+                )
+            )
+        for item in self.__bragg_peak_items:
+            self.viewer.addItem(item)
+        
+        self.add_circ_mask_btn.setEnabled(True)
+        self._worker.exit()
+
+class AutobraggpeakThread(WorkThread):
+    results_signal = QtCore.pyqtSignal(object)
+
+
+
+def parse_range(range_str):
+    """
+    Parse an integer range into a list of numbers.
+
+    Parameters
+    ----------
+    range_str : str
+        String of the form : "-10, 1:5, 10:50, 100, 101".
+        Ranges are inclusive (the endpoint is included). Can also be
+        an empty string.
+
+    Returns
+    -------
+    range : iterable of ints
+        Iterable of integers (possibly empty). Guaranteed to be sorted and unique.
+
+    Raises
+    ------
+    ValueError
+        if the input ``range_str`` is unparseable.
+    """
+    range_str = str(range_str)
+    range_str = range_str.replace(" ", "")
+    if not range_str:
+        return list()
+
+    elements = range_str.split(",")
+    if not elements:
+        return list()
+
+    iterable = list()
+
+    # Two possibilities : ints or ranges
+    # Either elem = int
+    # or     elem = start:stop
+    # Note : stop + 1 because inclusive ranges
+    for elem in elements:
+        try:
+            fl = int(elem)
+            iterable.append(fl)
+        except ValueError:
+            try:
+                start, stop = tuple(map(int, elem.split(":")))
+                iterable.extend(range(start, stop + 1))
+            except:
+                # Raise exception from None because full traceback is not useful
+                # especially in terms of GUI error messages
+                raise ValueError("Unparseable input: ", range_str) from None
+
+    return list(sorted(set(iterable)))

--- a/iris/gui/data_viewer.py
+++ b/iris/gui/data_viewer.py
@@ -171,6 +171,7 @@ class ProcessedDataViewer(QtWidgets.QWidget):
         enabled_bzs = params['enable_bz']
         voronoi_regions = params['bz']
         n_vertices = params['n_vertices']
+        self.bbox_size = int(0.025*self.image_viewer.getImageItem().image.shape[0])
         for item in self.__bragg_peak_items:
             self.image_viewer.removeItem(item)
         self.__bragg_peak_items.clear()
@@ -189,10 +190,10 @@ class ProcessedDataViewer(QtWidgets.QWidget):
                     pg.GraphItem(
                         pos = np.array(
                             [
-                                [c-25, r-25],
-                                [c-25, r+25],
-                                [c+25, r+25],
-                                [c+25,r-25]
+                                [c-self.bbox_size//2, r-self.bbox_size//2],
+                                [c-self.bbox_size//2, r+self.bbox_size//2],
+                                [c+self.bbox_size//2, r+self.bbox_size//2],
+                                [c+self.bbox_size//2,r-self.bbox_size//2]
                             ]
                         ),
                         adj = nodes,

--- a/iris/gui/gui.py
+++ b/iris/gui/gui.py
@@ -651,6 +651,7 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
         bragg_dialog = BraggPeakDialog(
             self.controller.dataset.diff_data(self.controller.dataset.time_points[0]),
             mask=self.controller.dataset.valid_mask,
+            pixel_width=self.controller.dataset.pixel_width,
             center=self.controller.dataset.center,
             parent=self,
         )

--- a/iris/gui/gui.py
+++ b/iris/gui/gui.py
@@ -18,6 +18,7 @@ from .. import AbstractRawDataset, __author__, __license__, __version__
 from ..dataset import SWMR_AVAILABLE
 from ..plugins import PLUGIN_DIR, install_plugin
 from .angular_average_dialog import AngularAverageDialog
+from .bragg_peak_dialog import BraggPeakDialog
 from .calibrate_q_dialog import QCalibratorDialog
 from .control_bar import ControlBar
 from .controller import ErrorAware, IrisController
@@ -119,7 +120,7 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
         # Including custom 'busy' indicator
         status_bar = QtWidgets.QStatusBar(parent=self)
         self.controller.status_message_signal.connect(
-            lambda msg: status_bar.showMessage(msg, int(20e3))
+            lambda msg: status_bar.showMessage(msg, 20e3)
         )
         self.setStatusBar(status_bar)
 
@@ -167,6 +168,8 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
         self.error_message_signal.connect(self.show_error_message)
 
         self.file_dialog = QtWidgets.QFileDialog(parent=self)
+        self.controller.file_dialog = self.file_dialog
+        self.controller.parent = self
         self.menu_bar = self.menuBar()
 
         self.viewer_stack = QtWidgets.QTabWidget()
@@ -300,6 +303,19 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
             self.calculate_azimuthal_averages_action.setEnabled
         )
 
+        self.calculate_bragg_peaks_action = QtWidgets.QAction(
+            QtGui.QIcon(join(IMAGE_FOLDER, "analysis.png")),
+            "& Calculate Bragg peaks",
+            self,
+        )
+        self.calculate_bragg_peaks_action.triggered.connect(
+            self.launch_calculate_bragg_peaks_dialog
+        )
+        self.controller.processed_dataset_loaded_signal.connect(
+            self.calculate_bragg_peaks_action.setEnabled
+        )
+
+
         self.update_metadata_action = QtWidgets.QAction(
             QtGui.QIcon(join(IMAGE_FOLDER, "save.png")),
             "& Update dataset metadata",
@@ -330,6 +346,7 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
         )
         self.diffraction_dataset_menu.addSeparator()
         self.diffraction_dataset_menu.addAction(self.calibrate_scattvector_action)
+        self.diffraction_dataset_menu.addAction(self.calculate_bragg_peaks_action)
 
         ###################
         # Display options
@@ -375,11 +392,36 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
             self.show_diff_relative_action.setEnabled
         )
 
-        self.show_bragg_peaks_action = QtWidgets.QAction("& Show Bragg peaks", self)
-        self.controller.processed_dataset_loaded_signal.connect(
+        self.show_bragg_peaks_action = QtWidgets.QAction(
+            "& Show Bragg peaks", self
+        )
+        self.show_bragg_peaks_action.setCheckable(True)
+        self.controller.bragg_peak_enable_signal.connect(
+            self.show_bragg_peaks_action.setChecked
+        )
+        self.show_bragg_peaks_action.toggled.connect(
+            self.controller.enable_bragg
+        )
+        self.controller.initially_run_bragg_signal.connect(
             self.show_bragg_peaks_action.setEnabled
         )
-        self.show_bragg_peaks_action.triggered.connect(self.controller.find_bragg_peaks)
+        self.show_bragg_peaks_action.setEnabled(False)
+
+        self.show_BZ_action = QtWidgets.QAction(
+            "& Show Brilluoin zones", self
+        )
+        self.show_BZ_action.setCheckable(True)
+        self.controller.bz_enable_signal.connect(
+            self.show_BZ_action.setChecked
+        )
+        self.show_BZ_action.toggled.connect(
+            self.controller.enable_bz
+        )
+        self.controller.initially_run_bragg_signal.connect(
+            self.show_BZ_action.setEnabled
+        )
+        self.show_BZ_action.setEnabled(False)
+
 
         self.show_powder_relative_action = QtWidgets.QAction(
             "& Toggle relative dynamics", self
@@ -438,6 +480,9 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
         )
         self.diffraction_dataset_display_options_menu.addAction(
             self.show_bragg_peaks_action
+        )
+        self.diffraction_dataset_display_options_menu.addAction(
+            self.show_BZ_action
         )
 
         self.powder_dataset_display_options_menu.addAction(
@@ -602,6 +647,23 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
         )
 
     @QtCore.pyqtSlot()
+    def launch_calculate_bragg_peaks_dialog(self):
+        bragg_dialog = BraggPeakDialog(
+            self.controller.dataset.diff_data(self.controller.dataset.time_points[0]),
+            mask=self.controller.dataset.valid_mask,
+            center=self.controller.dataset.center,
+            parent=self,
+        )
+        bragg_dialog.resize(0.75 * self.size())
+        bragg_dialog.bragg_peak_signal.connect(
+            self.controller.optimize_bragg_peaks
+        )
+        bragg_dialog.exec_()
+        bragg_dialog.bragg_peak_signal.disconnect(
+            self.controller.optimize_bragg_peaks
+        )
+
+    @QtCore.pyqtSlot()
     def launch_symmetrize_dialog(self):
         symmetrize_dialog = SymmetrizeDialog(
             parent=self,
@@ -674,7 +736,7 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
 
     @QtCore.pyqtSlot(bool)
     def update_available(self, available):
-        """Handle UI in case an update is available or not."""
+        """ Handle UI in case an update is available or not. """
         if available:
             self.update_action.setEnabled(True)
             self.update_action.setText("An update is available!")
@@ -733,7 +795,7 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
 
     @QtCore.pyqtSlot()
     def install_plugin(self):
-        """Load plug-in."""
+        """ Load plug-in. """
         explanation = INSTALL_PLUGIN_HELP.format(dir=PLUGIN_DIR)
 
         QtWidgets.QMessageBox.information(self, "Loading a plug-in", explanation)
@@ -749,7 +811,7 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
 
     @QtCore.pyqtSlot()
     def show_about(self):
-        """Show the About information"""
+        """ Show the About information """
 
         return QtWidgets.QMessageBox.about(self, "About Iris", make_about_string())
 


### PR DESCRIPTION
Added new Widget for the Diffraction Dataset options to allow for auto-identification of Bragg peaks via the new widget. Bragg peak positions optimized on dialog closed, as well as Brilluoin zones automatically computed. Parameter n_vertices adjusted in dialog to ensure only robustly determined BZ's included.