### PR TITLE
fixed `Q.StatusBar.showMessage` argument type

### DIFF
--- a/iris/gui/gui.py
+++ b/iris/gui/gui.py
@@ -120,7 +120,7 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
         # Including custom 'busy' indicator
         status_bar = QtWidgets.QStatusBar(parent=self)
         self.controller.status_message_signal.connect(
-            lambda msg: status_bar.showMessage(msg, 20e3)
+            lambda msg: status_bar.showMessage(msg, 20_000)
         )
         self.setStatusBar(status_bar)
 


### PR DESCRIPTION
iris used to crash whenever a statusbar message was emitted from this line...

from the documentation we see that the argument type of timeout has to be integer, rather than float:
```void QStatusBar::showMessage(const [QString](https://doc.qt.io/qt-6/qstring.html) &message, int timeout = 0)```
https://doc.qt.io/qt-6/qstatusbar.html#showMessage