### PR TITLE
added *.h5 to the file dialog filters

### DIFF
--- a/iris/gui/gui.py
+++ b/iris/gui/gui.py
@@ -739,7 +739,7 @@ class Iris(QtWidgets.QMainWindow, metaclass=ErrorAware):
     @QtCore.pyqtSlot()
     def load_dataset(self):
         path = self.file_dialog.getOpenFileName(
-            parent=self, caption="Load dataset", filter="*.hdf5"
+            parent=self, caption="Load dataset", filter="HDF5-files (*.h5 *.hdf5)"
         )[0]
         if not path:
             return

--- a/iris/gui/symmetrize_dialog.py
+++ b/iris/gui/symmetrize_dialog.py
@@ -167,7 +167,7 @@ class SymmetrizeDialog(QtWidgets.QDialog):
     @QtCore.pyqtSlot()
     def accept(self):
         self.file_dialog = QtWidgets.QFileDialog(parent=self)
-        filename = self.file_dialog.getSaveFileName(filter="*.hdf5")[0]
+        filename = self.file_dialog.getSaveFileName(filter="HDF5-files (*.h5 *.hdf5)")[0]
         if filename == "":
             return
 


### PR DESCRIPTION
I wasn't able to see my generated files ending in `.h5`. Since the extension is quite common, I added it to the filter in the file dialogs.