### PR TITLE
Wider t0 shift allowed. Robust image autorange and histogram.

### DIFF
--- a/iris/gui/control_bar.py
+++ b/iris/gui/control_bar.py
@@ -254,7 +254,7 @@ class DiffractionDatasetControl(QtWidgets.QFrame):
         # Time-zero shift control
         # QDoubleSpinbox does not have a slot that sets the value without notifying everybody
         self.time_zero_shift_widget = QtWidgets.QDoubleSpinBox(parent=self)
-        self.time_zero_shift_widget.setRange(-1000, 1000)
+        self.time_zero_shift_widget.setRange(-2000, 2000)
         self.time_zero_shift_widget.setDecimals(3)
         self.time_zero_shift_widget.setSingleStep(0.5)
         self.time_zero_shift_widget.setSuffix(" ps")

--- a/iris/gui/data_viewer.py
+++ b/iris/gui/data_viewer.py
@@ -66,6 +66,9 @@ class ProcessedDataViewer(QtWidgets.QWidget):
         self.layout.addWidget(self.time_series_widget)
         self.setLayout(self.layout)
 
+        self.histogram = self.image_viewer.getHistogramWidget()
+
+
     @QtCore.pyqtSlot()
     def update_timeseries_rect(self):
         rect = self.timeseries_rect_region.parentBounds().toRect()
@@ -142,10 +145,18 @@ class ProcessedDataViewer(QtWidgets.QWidget):
         if image is None:
             self.image_viewer.clear()
             return
-
         self.image_viewer.setImage(
-            image, autoLevels=autocontrast, autoRange=autocontrast
+            image, autoLevels=False, autoRange=False, autoHistogramRange=False
         )
+
+        if autocontrast:
+            low = np.quantile(image, 0.01)
+            high = np.quantile(image, 0.98)
+
+            self.image_viewer.setLevels(low, high)
+            self.histogram.setHistogramRange(low*.8, high*1.2)
+            self.histogram.setLevels(low, high)
+
         self.update_timeseries_rect()
 
     @QtCore.pyqtSlot(object, object)


### PR DESCRIPTION
I increased the range of adjustment for the time zero shift spin box since now the instrument scans between 0 and 2000 ps.

The histogram widget autoranges to the absolute min/max when a dataset is loaded. If the detector has a few saturated pixels, the histogram autoscales and autolevels to some obscurely high values. I used the 1% and 98% percentiles in hope that this is more robust.